### PR TITLE
feat(access_registry): Add SessionGrant storage for chain-driven KAS

### DIFF
--- a/contracts/access_registry/lib.rs
+++ b/contracts/access_registry/lib.rs
@@ -194,7 +194,7 @@ mod access_registry {
                 scope_id,
                 expires_at_block,
                 is_revoked: false,
-                created_at_block: self.env().block_number() as u64,
+                created_at_block: u64::from(self.env().block_number()),
             };
 
             self.sessions.insert(session_id, &grant);


### PR DESCRIPTION
## Summary

- Add `SessionGrant` struct for chain-driven access control with ephemeral key binding
- Add `sessions: Mapping<[u8; 32], SessionGrant>` storage field to contract
- Add `create_session`, `get_session`, `revoke_session` methods
- Add `SessionCreated` and `SessionRevoked` events
- Add comprehensive tests for session functionality

This enables arkavo-rs to query session grants from the blockchain for chain-driven rewrap operations.

## Test plan

- [x] Unit tests for `create_session` 
- [x] Unit tests for `get_session` (including unknown session)
- [x] Unit tests for `revoke_session` (including unknown session error)
- [ ] CI build and contract tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)