### PR TITLE
Add user_registry contract for DID-to-account linking

### DIFF
--- a/contracts/Cargo.lock
+++ b/contracts/Cargo.lock
@@ -9065,6 +9065,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "user_registry"
+version = "0.1.0"
+dependencies = [
+ "ink",
+ "ink_e2e",
+ "ink_sandbox",
+ "parity-scale-codec",
+ "scale-info",
+]
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "attribute_store",
     "policy_engine",
     "payment_integration",
+    "user_registry",
 ]
 resolver = "2"
 

--- a/contracts/user_registry/Cargo.toml
+++ b/contracts/user_registry/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "user_registry"
+version = "0.1.0"
+authors = ["Arkavo Team"]
+edition = "2024"
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ["cfg(ink_abi, values(any()))"] }
+
+[dependencies]
+ink = { version = "6.0.0-beta.1", default-features = false }
+
+scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11", default-features = false, features = ["derive"], optional = true }
+
+[dev-dependencies]
+ink_e2e = "6.0.0-beta.1"
+ink_sandbox = { git = "https://github.com/use-ink/ink.git", branch = "6.0.0-beta" }
+
+[lib]
+path = "lib.rs"
+
+[features]
+default = ["std"]
+std = [
+    "ink/std",
+    "scale/std",
+    "scale-info/std",
+]
+ink-as-dependency = []
+e2e-tests = []

--- a/contracts/user_registry/lib.rs
+++ b/contracts/user_registry/lib.rs
@@ -1,0 +1,301 @@
+#![cfg_attr(not(feature = "std"), no_std, no_main)]
+
+#[ink::contract]
+mod user_registry {
+    use ink::storage::Mapping;
+
+    /// User registry contract for linking DIDs to on-chain accounts.
+    ///
+    /// This contract provides a minimal, permanent binding between
+    /// decentralized identifiers (DIDs) and EVM addresses (H160).
+    /// Once linked, the binding cannot be changed or removed.
+    #[ink(storage)]
+    pub struct UserRegistry {
+        /// DID -> Address mapping (one-to-one, permanent)
+        did_to_account: Mapping<String, Address>,
+        /// Address -> DID mapping (reverse lookup)
+        account_to_did: Mapping<Address, String>,
+        /// Contract owner
+        owner: Address,
+        /// Total number of linked accounts
+        total_linked: u32,
+    }
+
+    /// Event emitted when an account is linked to a DID
+    #[ink(event)]
+    pub struct AccountLinked {
+        #[ink(topic)]
+        account: Address,
+        did: String,
+    }
+
+    /// Errors that can occur during contract execution
+    #[derive(Debug, PartialEq, Eq, Clone, scale::Encode, scale::Decode)]
+    #[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
+    pub enum Error {
+        /// DID is already linked to another account
+        DidAlreadyLinked,
+        /// Account is already linked to a DID
+        AccountAlreadyLinked,
+        /// Invalid DID format (must start with "did:key:")
+        InvalidDidFormat,
+        /// DID cannot be empty
+        EmptyDid,
+    }
+
+    pub type Result<T> = core::result::Result<T, Error>;
+
+    impl Default for UserRegistry {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+
+    impl UserRegistry {
+        /// Constructor that initializes the contract
+        #[ink(constructor)]
+        pub fn new() -> Self {
+            Self {
+                did_to_account: Mapping::default(),
+                account_to_did: Mapping::default(),
+                owner: Self::env().caller(),
+                total_linked: 0,
+            }
+        }
+
+        /// Link the caller's account to a DID.
+        ///
+        /// This is a one-time, permanent operation. Once linked:
+        /// - The DID cannot be linked to any other account
+        /// - The account cannot be linked to any other DID
+        ///
+        /// # Arguments
+        /// * `did` - The decentralized identifier to link (must start with "did:key:")
+        ///
+        /// # Errors
+        /// * `EmptyDid` - If the DID is empty
+        /// * `InvalidDidFormat` - If the DID doesn't start with "did:key:"
+        /// * `DidAlreadyLinked` - If the DID is already linked to another account
+        /// * `AccountAlreadyLinked` - If the caller's account is already linked to a DID
+        #[ink(message)]
+        pub fn link_account(&mut self, did: String) -> Result<()> {
+            let caller = self.env().caller();
+
+            // Validate DID format
+            if did.is_empty() {
+                return Err(Error::EmptyDid);
+            }
+            if !did.starts_with("did:key:") {
+                return Err(Error::InvalidDidFormat);
+            }
+
+            // Check if DID is already linked
+            if self.did_to_account.contains(&did) {
+                return Err(Error::DidAlreadyLinked);
+            }
+
+            // Check if account is already linked
+            if self.account_to_did.contains(caller) {
+                return Err(Error::AccountAlreadyLinked);
+            }
+
+            // Create permanent binding
+            self.did_to_account.insert(&did, &caller);
+            self.account_to_did.insert(caller, &did);
+            self.total_linked = self.total_linked.saturating_add(1);
+
+            // Emit event
+            self.env().emit_event(AccountLinked {
+                account: caller,
+                did,
+            });
+
+            Ok(())
+        }
+
+        /// Get the account linked to a DID
+        #[ink(message)]
+        pub fn get_account_by_did(&self, did: String) -> Option<Address> {
+            self.did_to_account.get(&did)
+        }
+
+        /// Get the DID linked to an account
+        #[ink(message)]
+        pub fn get_did_by_account(&self, account: Address) -> Option<String> {
+            self.account_to_did.get(account)
+        }
+
+        /// Check if an account has a linked DID
+        #[ink(message)]
+        pub fn is_linked(&self, account: Address) -> bool {
+            self.account_to_did.contains(account)
+        }
+
+        /// Check if a DID is already linked to an account
+        #[ink(message)]
+        pub fn is_did_linked(&self, did: String) -> bool {
+            self.did_to_account.contains(&did)
+        }
+
+        /// Get the total number of linked accounts
+        #[ink(message)]
+        pub fn total_linked(&self) -> u32 {
+            self.total_linked
+        }
+
+        /// Get the contract owner
+        #[ink(message)]
+        pub fn owner(&self) -> Address {
+            self.owner
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        fn set_caller(caller: Address) {
+            ink::env::test::set_caller(caller);
+        }
+
+        #[ink::test]
+        fn new_works() {
+            let contract = UserRegistry::new();
+            assert_eq!(contract.total_linked(), 0);
+            assert_eq!(contract.owner(), Address::default());
+        }
+
+        #[ink::test]
+        fn link_account_works() {
+            let alice = Address::from([0x01; 20]);
+            set_caller(alice);
+
+            let mut contract = UserRegistry::new();
+            let did = String::from("did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK");
+
+            assert!(contract.link_account(did.clone()).is_ok());
+            assert_eq!(contract.get_account_by_did(did.clone()), Some(alice));
+            assert_eq!(contract.get_did_by_account(alice), Some(did));
+            assert!(contract.is_linked(alice));
+            assert_eq!(contract.total_linked(), 1);
+        }
+
+        #[ink::test]
+        fn link_account_rejects_empty_did() {
+            let mut contract = UserRegistry::new();
+
+            assert_eq!(
+                contract.link_account(String::new()),
+                Err(Error::EmptyDid)
+            );
+        }
+
+        #[ink::test]
+        fn link_account_rejects_invalid_did_format() {
+            let mut contract = UserRegistry::new();
+
+            // Missing "did:key:" prefix
+            assert_eq!(
+                contract.link_account(String::from("z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK")),
+                Err(Error::InvalidDidFormat)
+            );
+
+            // Wrong DID method
+            assert_eq!(
+                contract.link_account(String::from("did:web:example.com")),
+                Err(Error::InvalidDidFormat)
+            );
+        }
+
+        #[ink::test]
+        fn link_account_rejects_duplicate_did() {
+            let alice = Address::from([0x01; 20]);
+            let bob = Address::from([0x02; 20]);
+            let mut contract = UserRegistry::new();
+            let did = String::from("did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK");
+
+            // First link succeeds
+            set_caller(alice);
+            assert!(contract.link_account(did.clone()).is_ok());
+
+            // Second link with same DID fails
+            set_caller(bob);
+            assert_eq!(
+                contract.link_account(did),
+                Err(Error::DidAlreadyLinked)
+            );
+        }
+
+        #[ink::test]
+        fn link_account_rejects_duplicate_account() {
+            let alice = Address::from([0x01; 20]);
+            set_caller(alice);
+
+            let mut contract = UserRegistry::new();
+            let did1 = String::from("did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK");
+            let did2 = String::from("did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH");
+
+            // First link succeeds
+            assert!(contract.link_account(did1).is_ok());
+
+            // Second link with different DID fails (account already linked)
+            assert_eq!(
+                contract.link_account(did2),
+                Err(Error::AccountAlreadyLinked)
+            );
+        }
+
+        #[ink::test]
+        fn multiple_accounts_can_link() {
+            let alice = Address::from([0x01; 20]);
+            let bob = Address::from([0x02; 20]);
+            let mut contract = UserRegistry::new();
+
+            let did1 = String::from("did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK");
+            let did2 = String::from("did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH");
+
+            // Alice links
+            set_caller(alice);
+            assert!(contract.link_account(did1.clone()).is_ok());
+
+            // Bob links with different DID
+            set_caller(bob);
+            assert!(contract.link_account(did2.clone()).is_ok());
+
+            // Verify both are linked correctly
+            assert_eq!(contract.get_account_by_did(did1), Some(alice));
+            assert_eq!(contract.get_account_by_did(did2), Some(bob));
+            assert_eq!(contract.total_linked(), 2);
+        }
+
+        #[ink::test]
+        fn is_did_linked_works() {
+            let alice = Address::from([0x01; 20]);
+            set_caller(alice);
+
+            let mut contract = UserRegistry::new();
+            let did = String::from("did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK");
+            let unlinked_did = String::from("did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH");
+
+            assert!(!contract.is_did_linked(did.clone()));
+
+            contract.link_account(did.clone()).unwrap();
+
+            assert!(contract.is_did_linked(did));
+            assert!(!contract.is_did_linked(unlinked_did));
+        }
+
+        #[ink::test]
+        fn get_returns_none_for_unlinked() {
+            let alice = Address::from([0x01; 20]);
+            let contract = UserRegistry::new();
+
+            assert_eq!(
+                contract.get_account_by_did(String::from("did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK")),
+                None
+            );
+            assert_eq!(contract.get_did_by_account(alice), None);
+            assert!(!contract.is_linked(alice));
+        }
+    }
+}

--- a/tools/deployer/README.md
+++ b/tools/deployer/README.md
@@ -22,6 +22,7 @@ cargo contract build --manifest-path access_registry/Cargo.toml
 cargo contract build --manifest-path attribute_store/Cargo.toml
 cargo contract build --manifest-path policy_engine/Cargo.toml
 cargo contract build --manifest-path payment_integration/Cargo.toml
+cargo contract build --manifest-path user_registry/Cargo.toml
 ```
 
 Contract artifacts are located in `contracts/target/ink/<contract_name>/`.
@@ -44,8 +45,9 @@ Contracts must be deployed in this order due to cross-contract dependencies:
 
 1. `access_registry` (standalone)
 2. `attribute_store` (standalone)
-3. `policy_engine` (requires access_registry and attribute_store addresses)
-4. `payment_integration` (requires access_registry address)
+3. `user_registry` (standalone - for DID-to-account linking)
+4. `policy_engine` (requires access_registry and attribute_store addresses)
+5. `payment_integration` (requires access_registry address)
 
 ### Step 1: Deploy access_registry
 
@@ -81,7 +83,23 @@ cargo contract instantiate \
 export ATTRIBUTE_STORE=0x...
 ```
 
-### Step 3: Deploy and Configure policy_engine
+### Step 3: Deploy user_registry
+
+```bash
+cargo contract instantiate \
+  --url $URL \
+  --suri //Alice \
+  --constructor new \
+  --skip-confirm \
+  --execute \
+  contracts/target/ink/user_registry/user_registry.contract
+```
+
+```bash
+export USER_REGISTRY=0x...
+```
+
+### Step 4: Deploy and Configure policy_engine
 
 ```bash
 cargo contract instantiate \
@@ -97,7 +115,7 @@ cargo contract instantiate \
 export POLICY_ENGINE=0x...
 ```
 
-Configure cross-contract references:
+Configure cross-contract references (note: step numbers updated):
 
 ```bash
 # Set access_registry address
@@ -123,7 +141,7 @@ cargo contract call \
   contracts/target/ink/policy_engine/policy_engine.contract
 ```
 
-### Step 4: Deploy and Configure payment_integration
+### Step 5: Deploy and Configure payment_integration
 
 ```bash
 cargo contract instantiate \
@@ -190,6 +208,30 @@ cargo contract call \
   contracts/target/ink/attribute_store/attribute_store.contract
 ```
 
+### Get Account by DID (user_registry)
+
+```bash
+cargo contract call \
+  --url $URL \
+  --contract $USER_REGISTRY \
+  --message get_account_by_did \
+  --args "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK" \
+  --suri //Alice \
+  contracts/target/ink/user_registry/user_registry.contract
+```
+
+### Check if Account is Linked (user_registry)
+
+```bash
+cargo contract call \
+  --url $URL \
+  --contract $USER_REGISTRY \
+  --message is_linked \
+  --args "0x0101010101010101010101010101010101010101" \
+  --suri //Alice \
+  contracts/target/ink/user_registry/user_registry.contract
+```
+
 ## Execute State Changes
 
 ### Grant Entitlement (Owner Only)
@@ -234,6 +276,24 @@ cargo contract call \
   contracts/target/ink/access_registry/access_registry.contract
 ```
 
+### Link Account to DID (user_registry)
+
+This is a one-time, permanent operation. Once linked, the binding cannot be changed.
+
+```bash
+cargo contract call \
+  --url $URL \
+  --contract $USER_REGISTRY \
+  --message link_account \
+  --args "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK" \
+  --suri //Bob \
+  --skip-confirm \
+  --execute \
+  contracts/target/ink/user_registry/user_registry.contract
+```
+
+Note: The caller's address (derived from --suri) will be permanently linked to the DID.
+
 ## Development Accounts
 
 The following development accounts are pre-funded on the dev chain:
@@ -253,6 +313,7 @@ The following development accounts are pre-funded on the dev chain:
 |----------|----------------------|
 | access_registry | None (standalone) |
 | attribute_store | None (standalone) |
+| user_registry | None (standalone) |
 | policy_engine | `set_access_registry()`, `set_attribute_store()` |
 | payment_integration | `set_access_registry()` |
 


### PR DESCRIPTION
## Summary
- Adds new `user_registry` smart contract for permanently linking DIDs to EVM addresses
- Implements one-time, permanent DID-to-account binding (no unlinking/relinking)
- Provides bidirectional lookups: `get_account_by_did()` and `get_did_by_account()`
- Validates DID format (must start with `did:key:`)
- Updates deployment documentation with user_registry instructions

## Test plan
- [x] All 9 unit tests pass (`cargo test` in contracts/user_registry)
- [ ] Deploy to local dev node and verify contract instantiation
- [ ] Test `link_account` with valid DID
- [ ] Test duplicate linking rejection (same DID or same account)
- [ ] Test bidirectional lookups

🤖 Generated with [Claude Code](https://claude.com/claude-code)